### PR TITLE
Fixed "java" binary variable in start.sh script

### DIFF
--- a/dist/src/main/package/bin/start.sh
+++ b/dist/src/main/package/bin/start.sh
@@ -51,7 +51,7 @@ if [[ "$_java" ]]; then
         then
           echo "Mycontroller.org server is already running on pid[${MC_PID}]"
         else
-          java ${HEAP_MIN} ${HEAP_MAX} -Dlogback.configurationFile=${CONF_LOG_FILE} -Dmc.conf.file=${CONF_PROPERTIES_FILE} -cp "../lib/*" org.mycontroller.standalone.StartApp >> ../logs/mycontroller.log 2>&1 &
+          $_java ${HEAP_MIN} ${HEAP_MAX} -Dlogback.configurationFile=${CONF_LOG_FILE} -Dmc.conf.file=${CONF_PROPERTIES_FILE} -cp "../lib/*" org.mycontroller.standalone.StartApp >> ../logs/mycontroller.log 2>&1 &
           echo 'Start issued for Mycontroller'
         fi
     else


### PR DESCRIPTION
Hi Jeeva,

I just installed MyController on a Linux machine for the first time and I realised that the "start.sh" script contains a little error - which causes that the Java binary could not be found properly. It's just a very little thing I corrected. Maybe you want to takeover the change into your dev branch.

Best regards,
Thomas