### PR TITLE
Fixed metric units for gust, pressure and wind

### DIFF
--- a/modules/core/src/main/java/org/mycontroller/standalone/units/UnitUtils.java
+++ b/modules/core/src/main/java/org/mycontroller/standalone/units/UnitUtils.java
@@ -36,7 +36,7 @@ public class UnitUtils {
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_DISTANCE, "cm", "mm", "m", 1.0, 100.0, 10.0, 100.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_EC, "μS/cm", "μS/cm", "μS/cm", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_FLOW, "m", "m", "m", 1.0, 1.0, 1.0, 1.0));
-        addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_GUST, "mph", "mph", "mph", 1.0, 1.0, 1.0, 1.0));
+        addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_GUST, "km/h", "km/h", "km/h", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_HUMIDITY, "%", "%", "%", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_IMPEDANCE, "Ω", "Ω", "KΩ", 1.0, 1000.0, 1.0, 1000.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_KWH, "kWh", "kWh", "kWh", 1.0, 1.0, 1.0, 1.0));
@@ -45,7 +45,7 @@ public class UnitUtils {
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_PERCENTAGE, "%", "%", "%", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_PH, "PH", "PH", "PH", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_POWER_FACTOR, "PF", "PF", "PF", 1.0, 1.0, 1.0, 1.0));
-        addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_PRESSURE, "psi", "psi", "psi", 1.0, 1.0, 1.0, 1.0));
+        addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_PRESSURE, "hPa", "hPa", "hPa", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_RAIN, "mm", "mm", "cm", 1.0, 10.0, 1.0, 10.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_RAINRATE, "mm/hr", "mm/hr", "cm/hr", 1.0, 10.0, 1.0, 10.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_TEMPERATURE, "°C", "°C", "°C", 1.0, 1.0, 1.0, 1.0));
@@ -55,7 +55,7 @@ public class UnitUtils {
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_VOLTAGE, "V", "mV", "V", 1.0, 1.0, 1000.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_WATT, "W", "mW", "W", 1.0, 1.0, 1000.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_WEIGHT, "kg", "g", "kg", 1.0, 1.0, 1000.0, 1.0));
-        addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_WIND, "mph", "mph", "mph", 1.0, 1.0, 1.0, 1.0));
+        addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_WIND, "km/h", "km/h", "km/h", 1.0, 1.0, 1.0, 1.0));
         addUnit(unitsMetric, Unit.get(UNIT_TYPE.U_NONE, "", "", "", 1.0, 1.0, 1.0, 1.0));
 
         //Update units Imperial


### PR DESCRIPTION
This is what I've changed:

Gust: mph -> km/h
Wind: mph -> km/h
Pressure: psi -> hPa ([this](https://en.wikipedia.org/wiki/International_System_of_Units) says, that Pa would be the correct derived SI-unit for pressure, but at least barometric pressure is almost always given in hPa and the mysensors [pressure example](https://github.com/mysensors/MySensorsArduinoExamples/blob/4e25d17f780d4677088e501a5eca9efe496ef22a/examples/PressureSensor/PressureSensor.ino) also returns hPa) - well, I'm not quite sure at this point as I think, that mysensors.org should specifiy the units each sensor returns... They [cannot even decide](https://www.mysensors.org/download/sensor_api_20#controller-configuration) whether to use "km/h" or "m/s" for speed. So I think for now, hPa is the best way to go.

For the imperial version of pressure, I'm even more unsure, so I didn't touch it... (and the mysensors pressure example also doesn't consider imperial units here) - but at least on most US weather forecast websites, they seem to use "hg" (mercury). On most UK websites, they use hPa or mbar (which are the same: 1hPa=1mbar)...