### PR TITLE
Update common_services.js

### DIFF
--- a/dist/src/main/package/www/services/common_services.js
+++ b/dist/src/main/package/www/services/common_services.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2017 Jeeva Kandasamy (jkandasa@gmail.com)
+ * Copyright 2015-2018 Jeeva Kandasamy (jkandasa@gmail.com)
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/dist/src/main/package/www/services/common_services.js
+++ b/dist/src/main/package/www/services/common_services.js
@@ -394,10 +394,11 @@ myControllerModule.factory('CommonServices', function(TypesFactory, $filter, $co
   //Function to convert rgba format to hex color
   commonService.rgba2hex = function rgb2hex(rgb){
     rgb = rgb.replace("rgba","").replace("(","").replace(")","").split(",");
-    return "#"+parseInt(rgb[0],10).toString(16)
-      + parseInt(rgb[1],10).toString(16)
-      + parseInt(rgb[2],10).toString(16)
-      + parseInt((parseFloat(rgb[3],10)*255)).toString(16);
+    return "#"
+      + ("0" + parseInt(rgb[0],10).toString(16)).slice(-2)
+      + ("0" + parseInt(rgb[1],10).toString(16)).slice(-2)
+      + ("0" + parseInt(rgb[2],10).toString(16)).slice(-2)
+      + ("0" + parseInt((parseFloat(rgb[3],10)*255)).toString(16)).slice(-2);
   };
 
   //Function to convert hex format to RGBA color


### PR DESCRIPTION
The rgba2hex function was not returning a valid hexadecimal value, the length must always be 8 characters (#RRGGBBWW). There is a condition that allows to send 4 characters instead of 8 but it is better not to shorten the value to facilitate the work in the program of the Arduino sketch.

Incorrect output:
58097 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=8,sg=0:#3d25a209
58531 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=8,sg=0:#3819be0
60297 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=8,sg=0:#3819bec
61145 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=6,sg=0:#fd16c
61790 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=5,sg=0:#334c

Correct output:
589207 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#07112400
589512 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#181e2900
590118 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#182b5200
590553 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#0e3f9e00
591108 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#229e0e00
591978 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#229e0e2b
592775 TSF:MSG:READ,0-0-5,s=0,c=1,t=41,pt=0,l=9,sg=0:#00080900

PS: The RGB picker works fine, only the RGBW picker failed.