### PR TITLE
Bugfix: Ethernet driver stops processing messages if not caught excep…

### DIFF
--- a/modules/core/src/main/java/org/mycontroller/standalone/gateway/ethernet/EthernetDriver.java
+++ b/modules/core/src/main/java/org/mycontroller/standalone/gateway/ethernet/EthernetDriver.java
@@ -164,7 +164,7 @@ class EthernetDataListener implements Runnable {
                     }
                 }
                 Thread.sleep(100);
-            } catch (IOException | InterruptedException | MessageParserException ex) {
+            } catch (Exception ex) {
                 _logger.error("Exception, ", ex);
             }
         }


### PR DESCRIPTION
I decided to catch all exceptions to be sure that in case of some message processing errors the driver thread will not exit.